### PR TITLE
Create store basic api swagger

### DIFF
--- a/src/main/java/com/clone/ohouse/shop/board/ProductBoardApiController.java
+++ b/src/main/java/com/clone/ohouse/shop/board/ProductBoardApiController.java
@@ -4,7 +4,9 @@ import com.clone.ohouse.shop.board.domain.ProductBoardService;
 import com.clone.ohouse.shop.board.domain.dto.ProductBoardResponseDto;
 import com.clone.ohouse.shop.board.domain.dto.ProductBoardSaveRequestDto;
 import com.clone.ohouse.shop.board.domain.dto.ProductBoardUpdateRequestDto;
+import io.swagger.annotations.*;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
@@ -12,24 +14,55 @@ import org.springframework.web.bind.annotation.*;
 public class ProductBoardApiController {
     private final ProductBoardService boardService;
 
+    @ApiOperation(
+            value = "제품 게시글 등록",
+            notes = "판매자가 제품을 등록하기 위해 사용합니다.",
+            code = 201)
+    @ApiResponses({
+            @ApiResponse(code = 500, message = "server error")
+    })
+    @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/store/productions")
-    public Long save(@RequestBody ProductBoardSaveRequestDto saveRequestDto){
-        return boardService.save(saveRequestDto);
+    public void save(@RequestBody ProductBoardSaveRequestDto saveRequestDto) {
+        boardService.save(saveRequestDto);
     }
 
+    @ApiOperation(
+            value = "제품 게시글 수정",
+            notes = "판매자 혹은 관리자가 게시글 수정에 사용합니다.",
+            code = 200)
+    @ApiResponse(code = 500, message = "server error")
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "id", value = "제품 게시글의 id (제품 id X)"),
+            @ApiImplicitParam(name = "updateRequestDto", value = " df dfsf")
+    })
+    @ResponseStatus(HttpStatus.OK)
     @PutMapping("/store/productions/{id}")
-    public Long update(@PathVariable Long id, @RequestBody ProductBoardUpdateRequestDto updateRequestDto){
-        return boardService.update(id, updateRequestDto);
+    public void update(@PathVariable Long id, @RequestBody ProductBoardUpdateRequestDto updateRequestDto) {
+        boardService.update(id, updateRequestDto);
     }
 
+    @ApiOperation(
+            value = "제품 게시글 얻기",
+            notes = "게시글에 대한 모든 내용을 가져옵니다. (title, content, 작성자, 수정일시, 수정자 등)",
+            code = 200)
+    @ApiResponse(code = 500, message = "server error")
+    @ApiImplicitParam(name = "id", value = "제품 게시글의 id (제품 id X)")
+    @ResponseStatus(HttpStatus.OK)
     @GetMapping("/store/productions/{id}")
-    public ProductBoardResponseDto findById(@PathVariable Long id){
+    public ProductBoardResponseDto findById(@PathVariable Long id) {
         return boardService.findById(id);
     }
-
+    @ApiOperation(
+            value = "제품 게시글 삭제",
+            notes = "게시글을 삭제합니다.",
+            code = 204)
+    @ApiResponse(code = 500, message = "server error")
+    @ApiImplicitParam(name = "id", value = "제품 게시글의 id (제품 id X)")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
     @DeleteMapping("/store/productions/{id}")
-    public Long delete(@PathVariable Long id){
-        return boardService.delete(id);
+    public void delete(@PathVariable Long id) {
+        boardService.delete(id);
     }
 
 }

--- a/src/main/java/com/clone/ohouse/shop/board/domain/dto/ProductBoardResponseDto.java
+++ b/src/main/java/com/clone/ohouse/shop/board/domain/dto/ProductBoardResponseDto.java
@@ -2,25 +2,83 @@ package com.clone.ohouse.shop.board.domain.dto;
 
 
 import com.clone.ohouse.shop.board.domain.entity.ProductBoard;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
-
+@ApiModel(
+        value = "store post response",
+        description = "게시글의 모든 내용을 담고 있습니다. 모든 내용이 ReadOnly입니다."
+)
 @AllArgsConstructor
 @Getter
 public class ProductBoardResponseDto {
+
+    @ApiModelProperty(
+            value = "store 게시글 id",
+            required = true,
+            accessMode = ApiModelProperty.AccessMode.READ_ONLY
+            )
     private Long id;
-    private boolean isActive;
+
+    @ApiModelProperty(
+            value = "store 글 제목",
+            required = true
+    )
     private String title;
+    @ApiModelProperty(
+            value = "store 글 내용, 내용 형태는 html 문서",
+            example = "<!DOCTYPE html>\n" +
+                    "<html lang=\"en\">\n" +
+                    "<head></head>" +
+                    "<body></body>" +
+                    "</html>"
+    )
     private String content;
+
+    @ApiModelProperty(
+            value = "작성자",
+            required = true
+    )
     private String author;
+
+    @ApiModelProperty(
+            value = "수정한 자, 수정한 적이 없다면 null입니다."
+    )
     private String modifiedUser;
-    private boolean isDeleted;
+
+    @ApiModelProperty(
+            value = "조회수",
+            allowableValues = "[0, infinity]"
+    )
     private Integer hit;
+
+    @ApiModelProperty(
+            value = "최초 생성일",
+            required = true
+
+    )
     private LocalDateTime createdDate;
+
+    @ApiModelProperty(
+            value = "수정 일"
+    )
     private LocalDateTime modifiedDate;
+
+    @ApiModelProperty(
+            value = "활성화 여부, 게시글이 활성화(보여질)지 아닐지 결정합니다.",
+            example = "false"
+    )
+    private boolean isActive;
+    @ApiModelProperty(
+            value = "삭제 여부, 게시글이 삭제되었는지 아닌지 결정합니다.",
+            example = "false"
+    )
+    private boolean isDeleted;
+
 
     public ProductBoardResponseDto(ProductBoard entity) {
         this.id = entity.getId();

--- a/src/main/java/com/clone/ohouse/shop/board/domain/dto/ProductBoardSaveRequestDto.java
+++ b/src/main/java/com/clone/ohouse/shop/board/domain/dto/ProductBoardSaveRequestDto.java
@@ -2,6 +2,8 @@ package com.clone.ohouse.shop.board.domain.dto;
 
 import com.clone.ohouse.shop.board.domain.entity.ProductBoard;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,27 +11,46 @@ import lombok.Setter;
 
 import java.nio.charset.StandardCharsets;
 
+@ApiModel(
+        value = "store post save request",
+        description = "판매자가 게시글을 생성하기 위한 것입니다"
+)
 @NoArgsConstructor
 @Getter
 public class ProductBoardSaveRequestDto {
+    @ApiModelProperty(
+            value = "store 글 제목",
+            required = true,
+            example = "임시 제목1")
     private String title;
-    private String content;
-    private String author;
-    private String modifiedUser;
 
-    public ProductBoardSaveRequestDto(String title, String content, String author, String modifiedUser) {
+    @ApiModelProperty(
+            value = "글 내용, 내용 형태는 html 문서",
+            example = "<!DOCTYPE html>\n" +
+                    "<html lang=\"en\">\n" +
+                    "<head></head>" +
+                    "<body></body>" +
+                    "</html>")
+    private String content;
+    @ApiModelProperty(
+            value = "작성자",
+            required = true,
+            example = "JJH"
+    )
+    private String author;
+
+
+    public ProductBoardSaveRequestDto(String title, String content, String author) {
         this.title = title;
         this.content = content;
         this.author = author;
-        this.modifiedUser = modifiedUser;
     }
 
-    public ProductBoard toEntity(){
+    public ProductBoard toEntity() {
         return ProductBoard.builder()
                 .title(title)
                 .content(content.getBytes(StandardCharsets.UTF_8))
                 .author(author)
-                .modifiedUser(modifiedUser)
                 .build();
     }
 

--- a/src/main/java/com/clone/ohouse/shop/board/domain/dto/ProductBoardUpdateRequestDto.java
+++ b/src/main/java/com/clone/ohouse/shop/board/domain/dto/ProductBoardUpdateRequestDto.java
@@ -1,21 +1,54 @@
 package com.clone.ohouse.shop.board.domain.dto;
 
 import com.clone.ohouse.shop.board.domain.entity.ProductBoard;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+@Api
+@ApiModel(
+        value = "store post update request",
+        description = "modifiedUser를 제외하고 모든 properties가 채워질 필요가 없습니다, 수정할 것만 채우면 됩니다. modifiedUser는 반드시 채워져야합니다."
+)
 @NoArgsConstructor
 @Getter
 @Setter
 public class ProductBoardUpdateRequestDto {
+    @ApiModelProperty(
+            value = "store 게시글 제목",
+            required = false,
+            example = "바뀐 제목1"
+    )
     private String title;
+
+    @ApiModelProperty(
+            value = "글 내용, 내용 형태는 html 문서",
+            example = "<html></html>"
+    )
     private String content;
+    @ApiModelProperty(
+            value = "수정한 자",
+            required = true,
+            example = "LMA"
+    )
     private String modifiedUser;
 
+    @ApiModelProperty(
+            value = "게시글을 활성화(보이도록)할지 비활성화 할지 결정하는 properties입니다.",
+            dataType = "boolean",
+            example = "false"
+    )
     private boolean isActive;
-    private boolean isDeleted;
+    @ApiModelProperty(
+            value = "게시글을 삭제 여부를 결정하는 properties입니다. (default is false)",
+            dataType = "boolean",
+            example = "false"
+    )
+    private boolean isDeleted = false;
 
     @Builder
     public ProductBoardUpdateRequestDto(String title, String content, String modifiedUser, boolean isActive, boolean isDeleted) {

--- a/src/main/java/com/clone/ohouse/shop/board/domain/dto/serializer/ByteParser.java
+++ b/src/main/java/com/clone/ohouse/shop/board/domain/dto/serializer/ByteParser.java
@@ -1,0 +1,15 @@
+package com.clone.ohouse.shop.board.domain.dto.serializer;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+import java.io.IOException;
+
+public class ByteParser extends JsonSerializer<byte[]> {
+    @Override
+    public void serialize(byte[] value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+
+        gen.writeRawUTF8String(value, 0, value.length);
+    }
+}

--- a/src/test/java/com/clone/ohouse/shop/board/ProductBoardApiControllerTest.java
+++ b/src/test/java/com/clone/ohouse/shop/board/ProductBoardApiControllerTest.java
@@ -74,7 +74,7 @@ class ProductBoardApiControllerTest {
         mvc.perform(MockMvcRequestBuilders.post(url)
                                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                                 .content(new ObjectMapper().writeValueAsString(saveRequestDto)))
-                .andExpect(MockMvcResultMatchers.status().isOk());
+                .andExpect(MockMvcResultMatchers.status().isCreated());
 
         //then
         List<ProductBoard> all = productBoardRepository.findAll();
@@ -156,7 +156,7 @@ class ProductBoardApiControllerTest {
 
         //when
         mvc.perform(MockMvcRequestBuilders.delete(url + String.valueOf(savedId)))
-                .andExpect(MockMvcResultMatchers.status().isOk());
+                .andExpect(MockMvcResultMatchers.status().isNoContent());
 
         Assertions.assertThat(productBoardRepository.count()).isEqualTo(0);
     }

--- a/src/test/java/com/clone/ohouse/shop/board/ProductBoardApiControllerTest.java
+++ b/src/test/java/com/clone/ohouse/shop/board/ProductBoardApiControllerTest.java
@@ -68,7 +68,7 @@ class ProductBoardApiControllerTest {
         String content = "klasdfjlkj34t42363gjerwovm";
         String author = "JJH";
         String modifiedUser = null;
-        ProductBoardSaveRequestDto saveRequestDto = new ProductBoardSaveRequestDto(title, content, author, modifiedUser);
+        ProductBoardSaveRequestDto saveRequestDto = new ProductBoardSaveRequestDto(title, content, author);
 
         //when
         mvc.perform(MockMvcRequestBuilders.post(url)
@@ -94,7 +94,7 @@ class ProductBoardApiControllerTest {
         String author = "JJH";
         String modifiedUser = null;
 
-        ProductBoardSaveRequestDto saveRequestDto = new ProductBoardSaveRequestDto(title, content, author, modifiedUser);
+        ProductBoardSaveRequestDto saveRequestDto = new ProductBoardSaveRequestDto(title, content, author);
         Long savedId = boardService.save(saveRequestDto);
 
         String title2 = "제목없음";
@@ -130,7 +130,7 @@ class ProductBoardApiControllerTest {
         String author = "JJH";
         String modifiedUser = null;
 
-        ProductBoardSaveRequestDto saveRequestDto = new ProductBoardSaveRequestDto(title, content, author, modifiedUser);
+        ProductBoardSaveRequestDto saveRequestDto = new ProductBoardSaveRequestDto(title, content, author);
         Long savedId = boardService.save(saveRequestDto);
 
         //when && then
@@ -151,7 +151,7 @@ class ProductBoardApiControllerTest {
         String author = "JJH";
         String modifiedUser = null;
 
-        ProductBoardSaveRequestDto saveRequestDto = new ProductBoardSaveRequestDto(title, content, author, modifiedUser);
+        ProductBoardSaveRequestDto saveRequestDto = new ProductBoardSaveRequestDto(title, content, author);
         Long savedId = boardService.save(saveRequestDto);
 
         //when

--- a/src/test/java/com/clone/ohouse/shop/board/domain/ProductBoardServiceTest.java
+++ b/src/test/java/com/clone/ohouse/shop/board/domain/ProductBoardServiceTest.java
@@ -118,9 +118,8 @@ public class ProductBoardServiceTest {
                 "Stay tuned to more out of Google I/O from Android Central!\n" +
                 "\n";
         String author = "고순무";
-        String modifiedUser = "고순무";
 
-        return new ProductBoardSaveRequestDto(title, content, author, modifiedUser);
+        return new ProductBoardSaveRequestDto(title, content, author);
     }
 
 }


### PR DESCRIPTION
- store의 CRUD api에 대해 swagger annotation 추가 
- API 중 일부 http response code 변경
    - save : 200 -> 201
    - delete : 200 -> 204
- API 중 일부 response 변경
    - save 의 경우 생성한 게시글 id를 body에 실었지만 이제는 반환X
    - update도 save와 마찬가지로 id를 body에 반환했지만 이제는 반환X

resolve : #23 